### PR TITLE
Move courier to foreground worker

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1175,6 +1175,10 @@
       "type": "boolean",
       "default": false
     },
+    "watch-courier": {
+      "type": "boolean",
+      "default": false
+    },
     "config": {
       "type": "array",
       "items": {

--- a/cmd/courier/root.go
+++ b/cmd/courier/root.go
@@ -1,0 +1,22 @@
+package courier
+
+import (
+	"github.com/ory/x/configx"
+	"github.com/spf13/cobra"
+)
+
+// courierCmd represents the courier command
+var courierCmd = &cobra.Command{
+	Use:   "courier",
+	Short: "Commands related to the ORY Kratos message courier",
+}
+
+func init() {
+	configx.RegisterFlags(courierCmd.PersistentFlags())
+}
+
+func RegisterCommandRecursive(parent *cobra.Command) {
+	parent.AddCommand(courierCmd)
+
+	courierCmd.AddCommand(watchCmd)
+}

--- a/cmd/courier/watch.go
+++ b/cmd/courier/watch.go
@@ -1,0 +1,37 @@
+package courier
+
+import (
+	cx "context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ory/graceful"
+	"github.com/ory/kratos/driver"
+	"github.com/ory/x/configx"
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Starts the ORY Kratos message courier",
+	Run: func(cmd *cobra.Command, args []string) {
+		d := driver.New(cmd.Context(), configx.WithFlags(cmd.Flags()))
+		Watch(d, cmd, args)
+	},
+}
+
+func Watch(d driver.Registry, cmd *cobra.Command, args []string) {
+	ctx, cancel := cx.WithCancel(cmd.Context())
+
+	d.Logger().Println("Courier worker started.")
+	if err := graceful.Graceful(func() error {
+		return d.Courier().Work(ctx)
+	}, func(_ cx.Context) error {
+		cancel()
+		return nil
+	}); err != nil {
+		d.Logger().WithError(err).Fatalf("Failed to run courier worker.")
+	}
+
+	d.Logger().Println("Courier worker was shutdown gracefully.")
+
+}

--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -1,13 +1,13 @@
 package daemon
 
 import (
-	cx "context"
 	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/ory/x/reqlog"
 
+	"github.com/ory/kratos/cmd/courier"
 	"github.com/ory/kratos/driver/config"
 
 	"github.com/ory/x/stringsx"
@@ -222,19 +222,9 @@ func sqa(cmd *cobra.Command, d driver.Registry) *metricsx.Service {
 func bgTasks(d driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args []string) {
 	defer wg.Done()
 
-	ctx, cancel := cx.WithCancel(cmd.Context())
-
-	d.Logger().Println("Courier worker started.")
-	if err := graceful.Graceful(func() error {
-		return d.Courier().Work(ctx)
-	}, func(_ cx.Context) error {
-		cancel()
-		return nil
-	}); err != nil {
-		d.Logger().WithError(err).Fatalf("Failed to run courier worker.")
+	if d.Config(cmd.Context()).IsBackgroundCourierEnabled() {
+		go courier.Watch(d, cmd, args)
 	}
-
-	d.Logger().Println("Courier worker was shutdown gracefully.")
 }
 
 func ServeAll(d driver.Registry, opts ...Option) func(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ory/kratos/driver/config"
 
+	"github.com/ory/kratos/cmd/courier"
 	"github.com/ory/kratos/cmd/hashers"
 
 	"github.com/ory/kratos/cmd/remote"
@@ -45,6 +46,7 @@ func init() {
 	migrate.RegisterCommandRecursive(RootCmd)
 	remote.RegisterCommandRecursive(RootCmd)
 	hashers.RegisterCommandRecursive(RootCmd)
+	courier.RegisterCommandRecursive(RootCmd)
 
 	RootCmd.AddCommand(cmdx.Version(&config.Version, &config.Commit, &config.Date))
 }

--- a/cmd/serve/root.go
+++ b/cmd/serve/root.go
@@ -62,4 +62,5 @@ func init() {
 
 	serveCmd.PersistentFlags().Bool("sqa-opt-out", false, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
 	serveCmd.PersistentFlags().Bool("dev", false, "Disables critical security features to make development easier")
+	serveCmd.PersistentFlags().Bool("watch-courier", false, "Run the message courier as a background task, to simplify single-instance setup")
 }

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -578,6 +578,10 @@ func (p *Config) IsInsecureDevMode() bool {
 	return p.Source().Bool("dev")
 }
 
+func (p *Config) IsBackgroundCourierEnabled() bool {
+	return p.Source().Bool("watch-courier")
+}
+
 func (p *Config) SelfServiceFlowVerificationUI() *url.URL {
 	return p.parseURIOrFail(ViperKeySelfServiceVerificationUI)
 }


### PR DESCRIPTION
Adds a new `kratos courier watch` command which runs the courier
Disables running the courier as a background task when `kratos serve` is called.
Running the courier as a background worker can be enabled with `kratos serve --watch-courier`.

Example docker-compose.yml:
```
version: "3.7"

services:
  kratos-migrate:
    image: oryd/kratos:v0.5.5-alpha.1-sqlite
    environment:
      - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true&mode=rwc
    volumes:
      - type: volume
        source: kratos-sqlite
        target: /var/lib/sqlite
        read_only: false
      - type: bind
        source: ./kratos
        target: /etc/config/kratos
    command: -c /etc/config/kratos/kratos.yml migrate sql -e --yes
    restart: on-failure
    networks:
      - intranet


  kratos:
    depends_on:
      - kratos-migrate
    image: oryd/kratos:v0.5.5-alpha.1-sqlite
    ports:
      - "4433:4433" # public
      - "4434:4434" # admin
    restart: unless-stopped
    environment:
      - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true
      - LOG_LEVEL=trace
    command: serve -c /etc/config/kratos/kratos.yml --dev
    volumes:
      - type: volume
        source: kratos-sqlite
        target: /var/lib/sqlite
        read_only: false
      - type: bind
        source: ./kratos
        target: /etc/config/kratos
    networks:
      - intranet

  kratos-courier:
    depends_on:
      - kratos-migrate
    image: registry-gitlab.i.wish.com/contextlogic/wish-accounts:wish.kratos.latest.courier
    restart: unless-stopped
    environment:
      - DSN=sqlite:///var/lib/sqlite/db.sqlite?_fk=true
      - LOG_LEVEL=trace
    command: courier watch -c /etc/config/kratos/kratos.yml
    volumes:
      - type: volume
        source: kratos-sqlite
        target: /var/lib/sqlite
        read_only: false
      - type: bind
        source: ./kratos
        target: /etc/config/kratos
    networks:
      - intranet

networks:
  intranet:

volumes:
  kratos-sqlite:
    external: false
  hydra-sqlite:
    external: false
```